### PR TITLE
fixing KB-12272: Global Search: “Clear All” removes filters but still…

### DIFF
--- a/sb-cb-ui-search-listing/package.json
+++ b/sb-cb-ui-search-listing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunbird-cb-ui-search-listing",
-  "version": "0.0.3-cbrelease-4.8.31",
+  "version": "0.0.4-cbrelease-4.8.31",
   "scripts": {
     "ng": "ng",
     "build": "node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng build",

--- a/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/package.json
+++ b/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunbird-cb/search-listing",
-  "version": "0.0.3-cbrelease-4.8.31",
+  "version": "0.0.4-cbrelease-4.8.31",
   "peerDependencies": {
     "@angular/common": "^16.2.12",
     "@angular/core": "^16.2.12",

--- a/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-filters/search-filters.component.html
+++ b/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-filters/search-filters.component.html
@@ -82,7 +82,7 @@
                 <mat-checkbox
                   [checked]="category?.isChecked || getSelectedFilter(category)"
                   [disabled]="category?.disabled"
-                  (change)="onSelectionFilter($event, category, category?.name)">
+                  (change)="onSelectionFilter($event, category, category?.name, true)">
                   <span class="min-width-adjust">
                     {{ category?.displayName }}
                   </span>

--- a/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-filters/search-filters.component.ts
+++ b/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-filters/search-filters.component.ts
@@ -143,7 +143,7 @@ export class SearchFiltersComponent implements OnInit, OnDestroy, OnChanges {
       const categorieTypes = this.searchConfig.allSearchCategoriesTypes || [];
 
       // normalize user roles which can be a Set<string> or string[]
-      const userRoles = (this.configSvc as any)?.userRoles as Set<string> | string[] | undefined;
+      const userRoles = (this.searchConfig?.applicationName === SearchListingConfig.ApplicationNames.CBPPortal ? (this.configSvc as any)?.userAllRoles : (this.configSvc as any)?.userRoles) as Set<string> | string[] | undefined;
       const userRolesArray: string[] = userRoles instanceof Set ? Array.from(userRoles) : Array.isArray(userRoles) ? (userRoles as string[]) : [];
       this.categoryType = categorieTypes.filter(cat => {
         // find the matching category config for this type
@@ -486,7 +486,13 @@ export class SearchFiltersComponent implements OnInit, OnDestroy, OnChanges {
       .join(" ");
   }
 
-  onSelectionFilter(event: MatCheckboxChange, option: any, categoryType: string) {
+  onSelectionFilter(event: MatCheckboxChange, option: any, categoryType: string, setRole =false) {
+    if (setRole && this.applicationName === SearchListingConfig.ApplicationNames.CBPPortal) {
+      const selectedCategory: any = _.get(this.searchConfig, 'searchCategories', []).find((category: any) => category.value === option.name);
+      if (selectedCategory) {
+        this.searchService.triggerSetRolesForCategory(selectedCategory.value, selectedCategory.roles);
+      }
+    }
     const type = option?.name;
     option.isChecked = event.checked;
     if (!this.selectedFilters[categoryType]) {

--- a/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-input-home/search-input-home.component.ts
+++ b/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_components/search-input-home/search-input-home.component.ts
@@ -162,6 +162,13 @@ export class SearchInputHomeComponent implements OnInit, OnChanges, OnDestroy {
         }
       })
     }
+
+    // Subscribe to setRolesForCategory triggers from service
+    this.searchSubscription.add(
+      this.searchListingService.setRolesForCategory$.subscribe((data: { category: string, roles?: string[] }) => {
+        this.setRolesForCategory(data.category, data.roles);
+      })
+    );
   }
 
   ngOnChanges( changes: SimpleChanges ) {
@@ -269,8 +276,8 @@ export class SearchInputHomeComponent implements OnInit, OnChanges, OnDestroy {
       }
       return category.roles.some(role => userRolesArray.includes(role.toLocaleLowerCase()));
     });
-    if (this.searchConfig && this.searchConfig.currentSearchCategories) {
-      this.searchConfig.currentSearchCategories = searchCategoriesCopy;
+    if (this.searchConfig) {
+      this.searchConfig['currentSearchCategories'] = searchCategoriesCopy;
     }
     this.categories = searchCategoriesCopy || [];
     return searchCategoriesCopy

--- a/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_services/search-listing.service.ts
+++ b/sb-cb-ui-search-listing/projects/sunbird-cb/search-listing/src/lib/_services/search-listing.service.ts
@@ -63,11 +63,20 @@ export class SearchListingService {
   private rolesSubject = new BehaviorSubject<string[]>([])
   updatedUserRoles$: Observable<string[]> = this.rolesSubject.asObservable()
 
+  // Subject to trigger setRolesForCategory from filters components
+  private setRolesForCategorySubject = new Subject<{ category: string, roles?: string[] }>()
+  setRolesForCategory$: Observable<{ category: string, roles?: string[] }> = this.setRolesForCategorySubject.asObservable()
+
   // userRoleIsFixed = new BehaviorSubject<boolean>(false)
   // userRoleIsFixed$: Observable<boolean> = this.userRoleIsFixed.asObservable()
 
   setUserRoles(roles: string[]) {
     this.rolesSubject.next(roles)
+  }
+
+  // Trigger setRolesForCategory in SearchInputHomeComponent
+  triggerSetRolesForCategory(category: string, roles?: string[]) {
+    this.setRolesForCategorySubject.next({ category, roles })
   }
 
   // setUserRoleIsFixed(fixed: boolean) {


### PR DESCRIPTION
… shows content and event