### PR TITLE
Cbrelease 4.8.39.1

### DIFF
--- a/sb-cb-ui-consumption/library/sunbird-cb/consumption/src/lib/_common/cards/card-portrait-ext/card-portrait-ext.component.html
+++ b/sb-cb-ui-consumption/library/sunbird-cb/consumption/src/lib/_common/cards/card-portrait-ext/card-portrait-ext.component.html
@@ -60,7 +60,7 @@
             <div class="duration-box right-corner" *ngIf="widgetData?.content?.duration > 0">
               <mat-icon class="mat-icon main_icon mr-1">access_time</mat-icon>
               <span class=" ws-mat-white-text duration">
-                {{ (widgetData?.content?.duration || 120)| pipeDurationTransform: 'hms' }}
+                {{ (checkForCiosDuration(widgetData?.content) || 120)| pipeDurationTransform: 'hms' }}
               </span>
             </div>
             <div class="duration-box right-corner" *ngIf="widgetData?.content?.programDuration > 0">

--- a/sb-cb-ui-consumption/library/sunbird-cb/consumption/src/lib/_common/cards/card-portrait-ext/card-portrait-ext.component.ts
+++ b/sb-cb-ui-consumption/library/sunbird-cb/consumption/src/lib/_common/cards/card-portrait-ext/card-portrait-ext.component.ts
@@ -49,10 +49,18 @@ export class CardPortraitExtComponent implements OnInit {
     return this.domainConfSvc.isConfigEnabled('components.cards', key)
   }
 
-  ngOnInit() {
-    if (this.widgetData && this.widgetData.content) {
-      this.widgetData.content.duration = this.widgetData.content.duration * 60
+  /* CIOS content — ids prefixed 'ext_' — already reports duration in seconds, so the x60
+     rendered 4500 as '75h' instead of '1h 15m'. Anything else routed through this card
+     still reports minutes. Resolved here rather than in ngOnInit so the shared content
+     object is left alone and a re-init cannot multiply the same value twice. */
+  checkForCiosDuration(content: any): number {
+    if (content && content.contentId && `${content.contentId}`.includes('ext_')) {
+      return Number(content.duration)
     }
+    return content?.duration * 60
+  }
+
+  ngOnInit() {
     const instanceConfig = this.configSvc.instanceConfig
     if (instanceConfig) {
       this.defaultThumbnail = instanceConfig.logos.defaultContent || ''


### PR DESCRIPTION
## Ticket

[[KB-15156](https://karmayogibharat.atlassian.net/browse/KB-15156)](https://karmayogibharat.atlassian.net/browse/KB-15156)

## What

Fixed an issue where the duration displayed for external content was incorrect.


## Why

For normal content, the duration is already provided in seconds, so there was no issue. However, for external content, the duration is provided in minutes, which caused a unit mismatch and resulted in the incorrect duration being displayed.

## How Tested

* Identified external content using the `ext_` prefix in the content ID.
* For external content, the duration is converted from minutes to seconds by multiplying it by `60`.
* Verified that the converted duration is displayed correctly.

## Checklist
in prod
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/9c0f7d4b-523e-4c27-8d12-575127cb7388" />


after fixed
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/97204731-a003-4f23-bbea-1c1238a813f9" />


[KB-15156]: https://karmayogibharat.atlassian.net/browse/KB-15156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ